### PR TITLE
Add basic login and expense screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,83 @@
 # SplitEasy
+
+Questa repository fornisce un esempio di struttura e alcuni suggerimenti per realizzare un'app mobile che aiuti a dividere le spese tra amici.
+
+## Caratteristiche principali
+- Registrazione e login degli utenti.
+- Creazione di gruppi e invito degli amici tramite email o link.
+- In ogni gruppo, ogni membro può aggiungere una spesa.
+- Le spese possono essere divise equamente tra tutti i membri o solo tra alcuni partecipanti.
+- Calcolo automatico dei debiti e crediti di ciascun partecipante.
+- Riepilogo finale per pareggiare i conti (ad esempio alla fine di una vacanza).
+
+## Tecnologie consigliate
+Per un approccio semplice e multipiattaforma è possibile utilizzare **React Native** con [Expo](https://expo.dev/). Per la gestione di autenticazione e database una soluzione pratica è **Firebase** (Authentication e Cloud Firestore).
+
+## Struttura dati di esempio
+Di seguito un possibile schema (in TypeScript) per i documenti salvati in Firestore.
+
+```ts
+export interface User {
+  uid: string;
+  email: string;
+  displayName: string;
+}
+
+export interface Group {
+  id: string;
+  name: string;
+  members: string[]; // array di uid degli utenti
+}
+
+export interface Split {
+  uid: string; // riferimento all'utente
+  amount: number; // quota attribuita
+}
+
+export interface Expense {
+  id: string;
+  groupId: string;
+  description: string;
+  amount: number;
+  paidBy: string; // uid di chi ha pagato
+  splits: Split[]; // elenco delle quote per ogni utente coinvolto
+}
+```
+
+## Esempio di componente React Native
+La cartella `example` contiene un piccolo esempio di app creato con Expo.
+
+Per eseguirlo è sufficiente installare le dipendenze (`npm install`) e avviare `expo start`.
+
+```tsx
+// example/App.tsx
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+import LoginScreen from './src/screens/LoginScreen';
+
+const Stack = createStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Login" component={LoginScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+```
+
+Nella cartella `src` sono presenti schermate di esempio (login, lista gruppi, nuova spesa) utili a sviluppare il resto dell'applicazione.
+
+## Passi successivi
+1. Inizializzare un progetto Expo (`npx create-expo-app SplitEasy`).
+2. Configurare Firebase per l'autenticazione e il database.
+3. Implementare le schermate di registrazione e login.
+4. Creare il flusso per la gestione dei gruppi (lista gruppi, creazione, inviti).
+5. Aggiungere la schermata per inserire nuove spese e scegliere come dividerle.
+6. Calcolare in automatico i totali dovuti/da ricevere per ogni membro del gruppo.
+7. Fornire un riepilogo finale che aiuti a saldare i conti.
+
+Questo è solo un punto di partenza; l'app può essere estesa con notifiche push, gestione delle valute, e sincronizzazione in tempo reale.

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+import LoginScreen from './src/screens/LoginScreen';
+import GroupsScreen from './src/screens/GroupsScreen';
+import AddExpenseScreen from './src/screens/AddExpenseScreen';
+
+const Stack = createStackNavigator();
+
+interface Group {
+  id: string;
+  name: string;
+}
+
+export default function App() {
+  const [loggedIn, setLoggedIn] = useState(false);
+  const [groups] = useState<Group[]>([
+    { id: '1', name: 'Vacanza' },
+    { id: '2', name: 'Casa' },
+  ]);
+
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        {!loggedIn ? (
+          <Stack.Screen name="Login">
+            {() => <LoginScreen onLogin={() => setLoggedIn(true)} />}
+          </Stack.Screen>
+        ) : (
+          <>
+            <Stack.Screen name="Gruppi">
+              {() => (
+                <GroupsScreen
+                  groups={groups}
+                  onAddExpense={() => {}}
+                />
+              )}
+            </Stack.Screen>
+            <Stack.Screen name="Nuova spesa">
+              {() => <AddExpenseScreen onSave={() => {}} />}
+            </Stack.Screen>
+          </>
+        )}
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/example/src/screens/AddExpenseScreen.tsx
+++ b/example/src/screens/AddExpenseScreen.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button } from 'react-native';
+
+interface Props {
+  onSave: (description: string, amount: number) => void;
+}
+
+export default function AddExpenseScreen({ onSave }: Props) {
+  const [description, setDescription] = useState('');
+  const [amount, setAmount] = useState('');
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', padding: 16 }}>
+      <TextInput
+        placeholder="Descrizione"
+        value={description}
+        onChangeText={setDescription}
+        style={{ marginBottom: 12, borderWidth: 1, padding: 8 }}
+      />
+      <TextInput
+        placeholder="Importo"
+        value={amount}
+        onChangeText={setAmount}
+        keyboardType="numeric"
+        style={{ marginBottom: 12, borderWidth: 1, padding: 8 }}
+      />
+      <Button title="Salva" onPress={() => onSave(description, parseFloat(amount))} />
+    </View>
+  );
+}

--- a/example/src/screens/GroupsScreen.tsx
+++ b/example/src/screens/GroupsScreen.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { View, Text, Button, FlatList } from 'react-native';
+
+interface Group {
+  id: string;
+  name: string;
+}
+
+interface Props {
+  groups: Group[];
+  onAddExpense: (group: Group) => void;
+}
+
+export default function GroupsScreen({ groups, onAddExpense }: Props) {
+  return (
+    <View style={{ flex: 1 }}>
+      <FlatList
+        data={groups}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <View style={{ padding: 16 }}>
+            <Text style={{ fontWeight: 'bold' }}>{item.name}</Text>
+            <Button title="Nuova spesa" onPress={() => onAddExpense(item)} />
+          </View>
+        )}
+      />
+    </View>
+  );
+}

--- a/example/src/screens/LoginScreen.tsx
+++ b/example/src/screens/LoginScreen.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button } from 'react-native';
+
+interface Props {
+  onLogin: () => void;
+}
+
+export default function LoginScreen({ onLogin }: Props) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', padding: 16 }}>
+      <TextInput
+        placeholder="Email"
+        value={email}
+        onChangeText={setEmail}
+        style={{ marginBottom: 12, borderWidth: 1, padding: 8 }}
+      />
+      <TextInput
+        placeholder="Password"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+        style={{ marginBottom: 12, borderWidth: 1, padding: 8 }}
+      />
+      <Button title="Accedi" onPress={onLogin} />
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- create initial React Native screens (login, groups list, add expense)
- wire them with React Navigation in `example/App.tsx`
- update README example snippet to mention the new screens

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6867ef3d6fe48321af6b5ba00c88fc01